### PR TITLE
chore(test): allow test is multipe GPG keys are present in the keychain

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -20,11 +20,6 @@ jobs:
           - 14
           - 16
 
-    env:
-      CITIZEN_STORAGE: file
-      CITIZEN_STORAGE_PATH: /tmp/citizen
-      DEBUG: 'citizen:*'
-
     steps:
       - uses: actions/checkout@v2
       - name: Import GPG key

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 dist/
 data/
 test/terraform-binaries/
+test/integration/fixture/.terraform/

--- a/lib/provider/provider.spec.js
+++ b/lib/provider/provider.spec.js
@@ -109,7 +109,7 @@ describe('provider cli', () => {
 
   describe('exportPublicKey()', () => {
     it('should export GPG public key', async () => {
-      const publicKey = await exportPublicKey();
+      const publicKey = await exportPublicKey(process.env.GPG_KEY_ID || null);
       expect(publicKey).to.include('PGP PUBLIC KEY BLOCK');
     });
 

--- a/test/download-terraform.js
+++ b/test/download-terraform.js
@@ -64,10 +64,12 @@ const download = async (terraform) => {
 
 exports.mochaHooks = {
   beforeAll: async () => {
+    const log = debug('citizen:test:download:beforeAll');
     try {
       await mkdir(TARGET_DIR);
     } catch (ignore) {
       // ignored when targetDir already exist
+      log(ignore);
     }
 
     await Promise.all(TERRAFORM_VERSIONS.map(download));

--- a/test/integration/terraform-cli.modules.spec.js
+++ b/test/integration/terraform-cli.modules.spec.js
@@ -6,6 +6,7 @@ const { execFile } = require('child_process');
 const { join } = require('path');
 const rimraf = promisify(require('rimraf'));
 const semver = require('semver');
+const debug = require('debug');
 
 const registry = require('./registry');
 const { moduleDb } = require('../../stores/store');
@@ -48,6 +49,7 @@ TERRAFORM_VERSIONS.forEach((terraform) => {
           await mkdir(targetDir);
         } catch (ignore) {
           // ignored when targetDir already exist
+          debug(`unable to create folder with reason : ${ignore}`);
         }
 
         const terraformDefinition = `module "vpc" {
@@ -82,6 +84,7 @@ TERRAFORM_VERSIONS.forEach((terraform) => {
         const cwd = join(__dirname, 'fixture');
 
         execFile(terraformCli, ['get'], { cwd }, (err, stdout, stderr) => {
+          debug(`unable to connect terraform-cli to the api with error ${err} and output\n${stdout}`);
           expect(stderr).to.include('no versions');
           done();
         });


### PR DESCRIPTION
Allow specifying the key to be used during the tests. At the moment users with multiple keys cannot run the tests.