### PR TITLE
Allow module names to have multiple-hyphens

### DIFF
--- a/lib/cli-helpers.js
+++ b/lib/cli-helpers.js
@@ -15,6 +15,11 @@ const isValidNamespace = (namespace) => namespaceRule.test(namespace);
 const nameRule = /^[a-zA-Z0-9]+-?[a-zA-Z0-9]+$/;
 const isValidName = (name) => nameRule.test(name);
 
+// The module name rule is
+const moduleRule = /^\b\w*([-]\w*\b){0,}$/;
+const isValidModuleName = (name) => moduleRule.test(name);
+
+
 // The version must be semantic version.
 const isValidVersion = (version) => semver.valid(version);
 
@@ -56,6 +61,7 @@ const makeTarball = (target = __dirname, filelist = []) => new Promise((resolve,
 module.exports = {
   isValidNamespace,
   isValidName,
+  isValidModuleName,
   isValidType: isValidName,
   isValidVersion,
   isValidProtocol,

--- a/lib/cli-helpers.js
+++ b/lib/cli-helpers.js
@@ -19,7 +19,6 @@ const isValidName = (name) => nameRule.test(name);
 const moduleRule = /^\b\w*([-]\w*\b){0,}$/;
 const isValidModuleName = (name) => moduleRule.test(name);
 
-
 // The version must be semantic version.
 const isValidVersion = (version) => semver.valid(version);
 

--- a/lib/cli-helpers.spec.js
+++ b/lib/cli-helpers.spec.js
@@ -10,6 +10,7 @@ const rimraf = require('rimraf');
 const {
   isValidNamespace,
   isValidName,
+  isValidModuleName,
   isValidVersion,
   isValidProtocol,
   makeFileList,
@@ -53,6 +54,43 @@ describe('cli-helpers', () => {
     it('should check module name which contain special characters', () => {
       const result = isValidName('terraform-aws-cons$ul');
       expect(result).to.be.false;
+    });
+  });
+
+  describe('isValidModuleName()', () => {
+    it('should check module consists of alphanumeric characters ', () => {
+      const result = isValidModuleName('1a2b3c');
+      expect(result).to.be.true;
+    });
+
+    it('should check namespace consists of alphanumeric characters or single hyphens', () => {
+      const result = isValidModuleName('abc-123');
+      expect(result).to.be.true;
+    });
+
+    it('should check namespace which begins with a hyphen', () => {
+      const result = isValidModuleName('-abc123');
+      expect(result).to.be.false;
+    });
+
+    it('should check namespace which ends with a hyphen', () => {
+      const result = isValidModuleName('abc123-');
+      expect(result).to.be.false;
+    });
+
+    it('should check namespace cannot have double hyphens', () => {
+      const result = isValidModuleName('abc--123');
+      expect(result).to.be.false;
+    });
+
+    it('should check namespace can have double hyphens', () => {
+      const result = isValidModuleName('tf-aws-abc');
+      expect(result).to.be.true;
+    });
+
+    it('should check namespace can have multiple hyphens', () => {
+      const result = isValidModuleName('tf-aws-abc-def-ghi');
+      expect(result).to.be.true;
     });
   });
 

--- a/lib/module/cli.js
+++ b/lib/module/cli.js
@@ -5,6 +5,7 @@ const ora = require('ora');
 const {
   isValidNamespace,
   isValidName,
+  isValidModuleName,
   isValidVersion,
   makeFileList,
   makeTarball,
@@ -32,7 +33,7 @@ module.exports = async (namespace, name, provider, version, cmd) => {
     process.exit(1);
   }
 
-  if (!isValidName(name)) {
+  if (!isValidModuleName(name)) {
     console.error('The name only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen.');
     process.exit(1);
   }


### PR DESCRIPTION
Our internal modules have names with multiple hyphens. This change allows these modules to be uploaded to the module registry from the citizen-cli tool.