### PR TITLE
provider prefix files should have terraform-provider prefix

### DIFF
--- a/lib/citizen.js
+++ b/lib/citizen.js
@@ -38,7 +38,7 @@ commander
   .description('Publish the terraform provider')
   .addHelpText('after', `
 Environment variables need to set:
-* CITIZEN_ADDR : citizen registry server address to publish a module`)
+* CITIZEN_ADDR : citizen registry server address to publish a provider`)
   .action(publishProvider);
 
 commander

--- a/lib/provider/cli.js
+++ b/lib/provider/cli.js
@@ -72,20 +72,20 @@ module.exports = async (namespace, type, version, protocols, cmd) => {
   const targetDir = process.cwd();
   const spinner = ora();
   // validation step
-  const fileNamePrefix = `${namespace}-${type}_${version}`;
+  const fileNamePrefix = `terraform-provider-${type}_${version}`;
   let providerData;
   try {
     spinner.text = `validate required files in ${targetDir}`;
     spinner.color = 'yellow';
     spinner.start();
-
+    console.log(`testing the existence of ${fileNamePrefix}`);
     const files = await readdir(targetDir);
     const providerRegex = new RegExp(`${fileNamePrefix}_(?<os>.*)_(?<arch>.*).zip`);
     const providerArchives = files.filter((f) => f.match(providerRegex));
 
     if (providerArchives.length === 0) {
       spinner.fail();
-      console.error(`There should be at least one zip archive matching file name ${namespace}-${type}_${version}_<os>_<arch>.zip`);
+      console.error(`There should be at least one zip archive matching file name terraform-provider-${type}_${version}_<os>_<arch>.zip`);
       process.exit(1);
     }
 

--- a/lib/provider/provider.spec.js
+++ b/lib/provider/provider.spec.js
@@ -131,7 +131,7 @@ describe('provider cli', () => {
     let targetDir;
     let cleanup;
     let shaSumsFile;
-    const prefix = 'outsider-citizen_0.3.1';
+    const prefix = 'terraform-provider-citizen_0.3.1';
     const providerPostfix1 = '_darwin_amd64';
     const providerPostfix2 = '_linux_amd64';
 

--- a/lib/provider/provider.spec.js
+++ b/lib/provider/provider.spec.js
@@ -53,7 +53,7 @@ describe('provider cli', () => {
     });
 
     it('should generate shasums file from zip files', async () => {
-      const prefix = 'citizen_0.1.1';
+      const prefix = 'terraform-provider-citizen_0.1.1';
       const shasumsFile = path.join(targetDir, `${prefix}_SHA256SUMS`);
       await genShaSums(prefix, targetDir);
 
@@ -74,7 +74,7 @@ describe('provider cli', () => {
         cleanup = cleanupCallback;
 
         try {
-          const prefix = 'citizen_0.1.1';
+          const prefix = 'terraform-provider-citizen_0.1.1';
           shaSumsFile = await genShaSums(prefix, targetDir);
           return done();
         } catch (e) {

--- a/lib/util.spec.js
+++ b/lib/util.spec.js
@@ -59,7 +59,7 @@ describe('util\'s', () => {
     let shasumFile;
 
     before(async () => {
-      const result = await generateProvider('citizen-null_1.0.0', ['linux_amd64', 'windows_amd64']);
+      const result = await generateProvider('null_1.0.0', ['linux_amd64', 'windows_amd64']);
       [targetDir, , shasumFile] = result; // eslint-disable-line no-unused-vars
     });
 
@@ -68,10 +68,10 @@ describe('util\'s', () => {
       const shasumsContent = await readFile(shasumFilePath, 'utf8');
       const result = await extractShasum(shasumsContent);
       expect(result)
-        .to.have.property('citizen-null_1.0.0_linux_amd64.zip')
+        .to.have.property('terraform-provider-null_1.0.0_linux_amd64.zip')
         .to.have.lengthOf.above(50);
       expect(result)
-        .to.have.property('citizen-null_1.0.0_windows_amd64.zip')
+        .to.have.property('terraform-provider-null_1.0.0_windows_amd64.zip')
         .to.have.lengthOf.above(50);
     });
   });

--- a/routes/providers.js
+++ b/routes/providers.js
@@ -104,7 +104,7 @@ router.post('/:namespace/:type/:version', (req, res, next) => {
       }
 
       const isFilesMatched = data.platforms
-        .every((p) => providerFiles.some((f) => f.filename === `${namespace}-${type}_${version}_${p.os}_${p.arch}.zip`));
+        .every((p) => providerFiles.some((f) => f.filename === `terraform-provider-${type}_${version}_${p.os}_${p.arch}.zip`));
       if (!isFilesMatched) {
         const error = new Error('Unmatched platform data and files');
         error.status = 400;
@@ -214,7 +214,7 @@ router.get('/:namespace/:type/:version/sha256sums', async (req, res, next) => {
   try {
     const options = { ...req.params };
 
-    const sumsLocation = `${options.namespace}/${options.type}/${options.version}/${options.namespace}-${options.type}_${options.version}_SHA256SUMS`;
+    const sumsLocation = `${options.namespace}/${options.type}/${options.version}/terraform-provider-${options.type}_${options.version}_SHA256SUMS`;
     const shasumsContent = await getProvider(sumsLocation);
     if (!shasumsContent) { return next(); }
 
@@ -234,7 +234,7 @@ router.get('/:namespace/:type/:version/sha256sums', async (req, res, next) => {
 router.get('/:namespace/:type/:version/sha256sums.sig', async (req, res, next) => {
   try {
     const options = { ...req.params };
-    const sigLocation = `${options.namespace}/${options.type}/${options.version}/${options.namespace}-${options.type}_${options.version}_SHA256SUMS.sig`;
+    const sigLocation = `${options.namespace}/${options.type}/${options.version}/terraform-provider-${options.type}_${options.version}_SHA256SUMS.sig`;
     const sig = await getProvider(sigLocation);
     if (!sig) { return next(); }
 
@@ -245,7 +245,7 @@ router.get('/:namespace/:type/:version/sha256sums.sig', async (req, res, next) =
 
     return res
       .set('Content-Type', 'application/octet-stream')
-      .set('Content-disposition', `attachment; filename=${options.namespace}-${options.type}_${options.version}_SHA256SUMS.sig`)
+      .set('Content-disposition', `attachment; filename=terraform-provider-${options.type}_${options.version}_SHA256SUMS.sig`)
       .send(sig);
   } catch (e) {
     return next(e);

--- a/routes/providers.spec.js
+++ b/routes/providers.spec.js
@@ -23,19 +23,19 @@ describe('POST /v1/providers/:namespace/:type/:version', () => {
       protocols: ['4.1', '5.0'],
       platforms: [
         {
-          filename: 'terrafrom-provider-null_1.0.0_linux_amd64.zip',
+          filename: 'terraform-provider-null_1.0.0_linux_amd64.zip',
           os: 'linux',
           arch: 'amd64',
         },
         {
-          filename: 'terrafrom-provider-null_1.0.0_windows_amd64.zip',
+          filename: 'terraform-provider-null_1.0.0_windows_amd64.zip',
           os: 'windows',
           arch: 'amd64',
         },
       ],
     };
     providerPath = 'citizen/null/1.0.0';
-    const result = await generateProvider('terrafrom-provider-null_1.0.0', ['linux_amd64', 'windows_amd64']);
+    const result = await generateProvider('terraform-provider-null_1.0.0', ['linux_amd64', 'windows_amd64']);
     [targetDir, cleanupProvider] = result;
   });
 
@@ -47,10 +47,10 @@ describe('POST /v1/providers/:namespace/:type/:version', () => {
 
   it('should register new provider', () => request(app)
     .post(`/v1/providers/${providerPath}`)
-    .attach('file1', `${targetDir}/terrafrom-provider-null_1.0.0_linux_amd64.zip`)
-    .attach('file2', `${targetDir}/terrafrom-provider-null_1.0.0_windows_amd64.zip`)
-    .attach('file3', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS`)
-    .attach('file4', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS.sig`)
+    .attach('file1', `${targetDir}/terraform-provider-null_1.0.0_linux_amd64.zip`)
+    .attach('file2', `${targetDir}/terraform-provider-null_1.0.0_windows_amd64.zip`)
+    .attach('file3', `${targetDir}/terraform-provider-null_1.0.0_SHA256SUMS`)
+    .attach('file4', `${targetDir}/terraform-provider-null_1.0.0_SHA256SUMS.sig`)
     .field('data', JSON.stringify(providerData))
     .expect('Content-Type', /application\/json/)
     .expect(201)
@@ -77,9 +77,9 @@ describe('POST /v1/providers/:namespace/:type/:version', () => {
 
   it('should return error if no sums file attached', () => request(app)
     .post(`/v1/providers/${providerPath}`)
-    .attach('file1', `${targetDir}/terrafrom-provider-null_1.0.0_linux_amd64.zip`)
-    .attach('file2', `${targetDir}/terrafrom-provider-null_1.0.0_windows_amd64.zip`)
-    .attach('file3', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS.sig`)
+    .attach('file1', `${targetDir}/terraform-provider-null_1.0.0_linux_amd64.zip`)
+    .attach('file2', `${targetDir}/terraform-provider-null_1.0.0_windows_amd64.zip`)
+    .attach('file3', `${targetDir}/terraform-provider-null_1.0.0_SHA256SUMS.sig`)
     .field('data', JSON.stringify(providerData))
     .expect('Content-Type', /application\/json/)
     .expect(400)
@@ -90,9 +90,9 @@ describe('POST /v1/providers/:namespace/:type/:version', () => {
 
   it('should return error if no signature file attached', () => request(app)
     .post(`/v1/providers/${providerPath}`)
-    .attach('file1', `${targetDir}/terrafrom-provider-null_1.0.0_linux_amd64.zip`)
-    .attach('file2', `${targetDir}/terrafrom-provider-null_1.0.0_windows_amd64.zip`)
-    .attach('file3', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS`)
+    .attach('file1', `${targetDir}/terraform-provider-null_1.0.0_linux_amd64.zip`)
+    .attach('file2', `${targetDir}/terraform-provider-null_1.0.0_windows_amd64.zip`)
+    .attach('file3', `${targetDir}/terraform-provider-null_1.0.0_SHA256SUMS`)
     .field('data', JSON.stringify(providerData))
     .expect('Content-Type', /application\/json/)
     .expect(400)
@@ -107,10 +107,10 @@ describe('POST /v1/providers/:namespace/:type/:version', () => {
 
     return request(app)
       .post(`/v1/providers/${providerPath}`)
-      .attach('file1', `${targetDir}/terrafrom-provider-null_1.0.0_linux_amd64.zip`)
-      .attach('file2', `${targetDir}/terrafrom-provider-null_1.0.0_windows_amd64.zip`)
-      .attach('file3', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS`)
-      .attach('file4', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS.sig`)
+      .attach('file1', `${targetDir}/terraform-provider-null_1.0.0_linux_amd64.zip`)
+      .attach('file2', `${targetDir}/terraform-provider-null_1.0.0_windows_amd64.zip`)
+      .attach('file3', `${targetDir}/terraform-provider-null_1.0.0_SHA256SUMS`)
+      .attach('file4', `${targetDir}/terraform-provider-null_1.0.0_SHA256SUMS.sig`)
       .field('data', JSON.stringify(data))
       .expect('Content-Type', /application\/json/)
       .expect(400)
@@ -127,10 +127,10 @@ describe('POST /v1/providers/:namespace/:type/:version', () => {
 
     return request(app)
       .post(`/v1/providers/${providerPath}`)
-      .attach('file1', `${targetDir}/terrafrom-provider-null_1.0.0_linux_amd64.zip`)
-      .attach('file2', `${targetDir}/terrafrom-provider-null_1.0.0_windows_amd64.zip`)
-      .attach('file3', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS`)
-      .attach('file4', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS.sig`)
+      .attach('file1', `${targetDir}/terraform-provider-null_1.0.0_linux_amd64.zip`)
+      .attach('file2', `${targetDir}/terraform-provider-null_1.0.0_windows_amd64.zip`)
+      .attach('file3', `${targetDir}/terraform-provider-null_1.0.0_SHA256SUMS`)
+      .attach('file4', `${targetDir}/terraform-provider-null_1.0.0_SHA256SUMS.sig`)
       .field('data', JSON.stringify(providerData))
       .expect('Content-Type', /application\/json/)
       .expect(409)
@@ -184,27 +184,27 @@ describe('GET /v1/providers/:namespace/:type/:version/download/:os/:arch', () =>
       protocols: ['4.1', '5.0'],
       platforms: [
         {
-          filename: 'terrafrom-provider-null_1.0.0_linux_amd64.zip',
+          filename: 'terraform-provider-null_1.0.0_linux_amd64.zip',
           os: 'linux',
           arch: 'amd64',
         },
         {
-          filename: 'terrafrom-provider-null_1.0.0_windows_amd64.zip',
+          filename: 'terraform-provider-null_1.0.0_windows_amd64.zip',
           os: 'windows',
           arch: 'amd64',
         },
       ],
     };
     const providerPath = 'citizen/null/1.0.0';
-    const result = await generateProvider('terrafrom-provider-null_1.0.0', ['linux_amd64', 'windows_amd64']);
+    const result = await generateProvider('terraform-provider-null_1.0.0', ['linux_amd64', 'windows_amd64']);
     [targetDir, cleanupProvider] = result;
 
     return request(app)
       .post(`/v1/providers/${providerPath}`)
-      .attach('file1', `${targetDir}/terrafrom-provider-null_1.0.0_linux_amd64.zip`)
-      .attach('file2', `${targetDir}/terrafrom-provider-null_1.0.0_windows_amd64.zip`)
-      .attach('file3', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS`)
-      .attach('file4', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS.sig`)
+      .attach('file1', `${targetDir}/terraform-provider-null_1.0.0_linux_amd64.zip`)
+      .attach('file2', `${targetDir}/terraform-provider-null_1.0.0_windows_amd64.zip`)
+      .attach('file3', `${targetDir}/terraform-provider-null_1.0.0_SHA256SUMS`)
+      .attach('file4', `${targetDir}/terraform-provider-null_1.0.0_SHA256SUMS.sig`)
       .field('data', JSON.stringify(providerData))
       .expect('Content-Type', /application\/json/)
       .expect(201);
@@ -225,7 +225,7 @@ describe('GET /v1/providers/:namespace/:type/:version/download/:os/:arch', () =>
       expect(res.body).to.have.property('arch').to.equal('amd64');
       expect(res.body).to.have.property('protocols').to.include('4.1');
       expect(res.body).to.have.property('protocols').to.include('5.0');
-      expect(res.body).to.have.property('filename').to.equal('terrafrom-provider-null_1.0.0_linux_amd64.zip');
+      expect(res.body).to.have.property('filename').to.equal('terraform-provider-null_1.0.0_linux_amd64.zip');
       expect(res.body).to.have.property('download_url');
       expect(res.body).to.have.property('shasums_url');
       expect(res.body).to.have.property('shasums_signature_url');
@@ -244,7 +244,7 @@ describe('GET /v1/providers/:namespace/:type/:version/download/:os/:arch', () =>
           await server
             .get(downloadUrl)
             .expect('Content-Type', /application\/zip/)
-            .expect('Content-Disposition', /terrafrom-provider-null_1\.0\.0_linux_amd64\.zip/)
+            .expect('Content-Disposition', /terraform-provider-null_1\.0\.0_linux_amd64\.zip/)
             .expect(200);
 
           const host = await server.get('/').url;
@@ -289,8 +289,8 @@ describe('GET /v1/providers/:namespace/:type/:version/download/:os/:arch', () =>
           .expect('Content-Type', /text\/plain/)
           .expect(200)
           .then((res) => {
-            expect(res.text).to.include('terrafrom-provider-null_1.0.0_linux_amd64.zip');
-            expect(res.text).to.include('terrafrom-provider-null_1.0.0_windows_amd64.zip');
+            expect(res.text).to.include('terraform-provider-null_1.0.0_linux_amd64.zip');
+            expect(res.text).to.include('terraform-provider-null_1.0.0_windows_amd64.zip');
           }));
     });
 

--- a/routes/providers.spec.js
+++ b/routes/providers.spec.js
@@ -35,7 +35,7 @@ describe('POST /v1/providers/:namespace/:type/:version', () => {
       ],
     };
     providerPath = 'citizen/null/1.0.0';
-    const result = await generateProvider('terraform-provider-null_1.0.0', ['linux_amd64', 'windows_amd64']);
+    const result = await generateProvider('null_1.0.0', ['linux_amd64', 'windows_amd64']);
     [targetDir, cleanupProvider] = result;
   });
 
@@ -196,7 +196,7 @@ describe('GET /v1/providers/:namespace/:type/:version/download/:os/:arch', () =>
       ],
     };
     const providerPath = 'citizen/null/1.0.0';
-    const result = await generateProvider('terraform-provider-null_1.0.0', ['linux_amd64', 'windows_amd64']);
+    const result = await generateProvider('null_1.0.0', ['linux_amd64', 'windows_amd64']);
     [targetDir, cleanupProvider] = result;
 
     return request(app)

--- a/routes/providers.spec.js
+++ b/routes/providers.spec.js
@@ -23,19 +23,19 @@ describe('POST /v1/providers/:namespace/:type/:version', () => {
       protocols: ['4.1', '5.0'],
       platforms: [
         {
-          filename: 'citizen-null_1.0.0_linux_amd64.zip',
+          filename: 'terrafrom-provider-null_1.0.0_linux_amd64.zip',
           os: 'linux',
           arch: 'amd64',
         },
         {
-          filename: 'citizen-null_1.0.0_windows_amd64.zip',
+          filename: 'terrafrom-provider-null_1.0.0_windows_amd64.zip',
           os: 'windows',
           arch: 'amd64',
         },
       ],
     };
     providerPath = 'citizen/null/1.0.0';
-    const result = await generateProvider('citizen-null_1.0.0', ['linux_amd64', 'windows_amd64']);
+    const result = await generateProvider('terrafrom-provider-null_1.0.0', ['linux_amd64', 'windows_amd64']);
     [targetDir, cleanupProvider] = result;
   });
 
@@ -47,10 +47,10 @@ describe('POST /v1/providers/:namespace/:type/:version', () => {
 
   it('should register new provider', () => request(app)
     .post(`/v1/providers/${providerPath}`)
-    .attach('file1', `${targetDir}/citizen-null_1.0.0_linux_amd64.zip`)
-    .attach('file2', `${targetDir}/citizen-null_1.0.0_windows_amd64.zip`)
-    .attach('file3', `${targetDir}/citizen-null_1.0.0_SHA256SUMS`)
-    .attach('file4', `${targetDir}/citizen-null_1.0.0_SHA256SUMS.sig`)
+    .attach('file1', `${targetDir}/terrafrom-provider-null_1.0.0_linux_amd64.zip`)
+    .attach('file2', `${targetDir}/terrafrom-provider-null_1.0.0_windows_amd64.zip`)
+    .attach('file3', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS`)
+    .attach('file4', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS.sig`)
     .field('data', JSON.stringify(providerData))
     .expect('Content-Type', /application\/json/)
     .expect(201)
@@ -77,9 +77,9 @@ describe('POST /v1/providers/:namespace/:type/:version', () => {
 
   it('should return error if no sums file attached', () => request(app)
     .post(`/v1/providers/${providerPath}`)
-    .attach('file1', `${targetDir}/citizen-null_1.0.0_linux_amd64.zip`)
-    .attach('file2', `${targetDir}/citizen-null_1.0.0_windows_amd64.zip`)
-    .attach('file3', `${targetDir}/citizen-null_1.0.0_SHA256SUMS.sig`)
+    .attach('file1', `${targetDir}/terrafrom-provider-null_1.0.0_linux_amd64.zip`)
+    .attach('file2', `${targetDir}/terrafrom-provider-null_1.0.0_windows_amd64.zip`)
+    .attach('file3', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS.sig`)
     .field('data', JSON.stringify(providerData))
     .expect('Content-Type', /application\/json/)
     .expect(400)
@@ -90,9 +90,9 @@ describe('POST /v1/providers/:namespace/:type/:version', () => {
 
   it('should return error if no signature file attached', () => request(app)
     .post(`/v1/providers/${providerPath}`)
-    .attach('file1', `${targetDir}/citizen-null_1.0.0_linux_amd64.zip`)
-    .attach('file2', `${targetDir}/citizen-null_1.0.0_windows_amd64.zip`)
-    .attach('file3', `${targetDir}/citizen-null_1.0.0_SHA256SUMS`)
+    .attach('file1', `${targetDir}/terrafrom-provider-null_1.0.0_linux_amd64.zip`)
+    .attach('file2', `${targetDir}/terrafrom-provider-null_1.0.0_windows_amd64.zip`)
+    .attach('file3', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS`)
     .field('data', JSON.stringify(providerData))
     .expect('Content-Type', /application\/json/)
     .expect(400)
@@ -107,10 +107,10 @@ describe('POST /v1/providers/:namespace/:type/:version', () => {
 
     return request(app)
       .post(`/v1/providers/${providerPath}`)
-      .attach('file1', `${targetDir}/citizen-null_1.0.0_linux_amd64.zip`)
-      .attach('file2', `${targetDir}/citizen-null_1.0.0_windows_amd64.zip`)
-      .attach('file3', `${targetDir}/citizen-null_1.0.0_SHA256SUMS`)
-      .attach('file4', `${targetDir}/citizen-null_1.0.0_SHA256SUMS.sig`)
+      .attach('file1', `${targetDir}/terrafrom-provider-null_1.0.0_linux_amd64.zip`)
+      .attach('file2', `${targetDir}/terrafrom-provider-null_1.0.0_windows_amd64.zip`)
+      .attach('file3', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS`)
+      .attach('file4', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS.sig`)
       .field('data', JSON.stringify(data))
       .expect('Content-Type', /application\/json/)
       .expect(400)
@@ -127,10 +127,10 @@ describe('POST /v1/providers/:namespace/:type/:version', () => {
 
     return request(app)
       .post(`/v1/providers/${providerPath}`)
-      .attach('file1', `${targetDir}/citizen-null_1.0.0_linux_amd64.zip`)
-      .attach('file2', `${targetDir}/citizen-null_1.0.0_windows_amd64.zip`)
-      .attach('file3', `${targetDir}/citizen-null_1.0.0_SHA256SUMS`)
-      .attach('file4', `${targetDir}/citizen-null_1.0.0_SHA256SUMS.sig`)
+      .attach('file1', `${targetDir}/terrafrom-provider-null_1.0.0_linux_amd64.zip`)
+      .attach('file2', `${targetDir}/terrafrom-provider-null_1.0.0_windows_amd64.zip`)
+      .attach('file3', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS`)
+      .attach('file4', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS.sig`)
       .field('data', JSON.stringify(providerData))
       .expect('Content-Type', /application\/json/)
       .expect(409)
@@ -184,27 +184,27 @@ describe('GET /v1/providers/:namespace/:type/:version/download/:os/:arch', () =>
       protocols: ['4.1', '5.0'],
       platforms: [
         {
-          filename: 'citizen-null_1.0.0_linux_amd64.zip',
+          filename: 'terrafrom-provider-null_1.0.0_linux_amd64.zip',
           os: 'linux',
           arch: 'amd64',
         },
         {
-          filename: 'citizen-null_1.0.0_windows_amd64.zip',
+          filename: 'terrafrom-provider-null_1.0.0_windows_amd64.zip',
           os: 'windows',
           arch: 'amd64',
         },
       ],
     };
     const providerPath = 'citizen/null/1.0.0';
-    const result = await generateProvider('citizen-null_1.0.0', ['linux_amd64', 'windows_amd64']);
+    const result = await generateProvider('terrafrom-provider-null_1.0.0', ['linux_amd64', 'windows_amd64']);
     [targetDir, cleanupProvider] = result;
 
     return request(app)
       .post(`/v1/providers/${providerPath}`)
-      .attach('file1', `${targetDir}/citizen-null_1.0.0_linux_amd64.zip`)
-      .attach('file2', `${targetDir}/citizen-null_1.0.0_windows_amd64.zip`)
-      .attach('file3', `${targetDir}/citizen-null_1.0.0_SHA256SUMS`)
-      .attach('file4', `${targetDir}/citizen-null_1.0.0_SHA256SUMS.sig`)
+      .attach('file1', `${targetDir}/terrafrom-provider-null_1.0.0_linux_amd64.zip`)
+      .attach('file2', `${targetDir}/terrafrom-provider-null_1.0.0_windows_amd64.zip`)
+      .attach('file3', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS`)
+      .attach('file4', `${targetDir}/terrafrom-provider-null_1.0.0_SHA256SUMS.sig`)
       .field('data', JSON.stringify(providerData))
       .expect('Content-Type', /application\/json/)
       .expect(201);
@@ -225,7 +225,7 @@ describe('GET /v1/providers/:namespace/:type/:version/download/:os/:arch', () =>
       expect(res.body).to.have.property('arch').to.equal('amd64');
       expect(res.body).to.have.property('protocols').to.include('4.1');
       expect(res.body).to.have.property('protocols').to.include('5.0');
-      expect(res.body).to.have.property('filename').to.equal('citizen-null_1.0.0_linux_amd64.zip');
+      expect(res.body).to.have.property('filename').to.equal('terrafrom-provider-null_1.0.0_linux_amd64.zip');
       expect(res.body).to.have.property('download_url');
       expect(res.body).to.have.property('shasums_url');
       expect(res.body).to.have.property('shasums_signature_url');
@@ -244,7 +244,7 @@ describe('GET /v1/providers/:namespace/:type/:version/download/:os/:arch', () =>
           await server
             .get(downloadUrl)
             .expect('Content-Type', /application\/zip/)
-            .expect('Content-Disposition', /citizen-null_1\.0\.0_linux_amd64\.zip/)
+            .expect('Content-Disposition', /terrafrom-provider-null_1\.0\.0_linux_amd64\.zip/)
             .expect(200);
 
           const host = await server.get('/').url;
@@ -289,8 +289,8 @@ describe('GET /v1/providers/:namespace/:type/:version/download/:os/:arch', () =>
           .expect('Content-Type', /text\/plain/)
           .expect(200)
           .then((res) => {
-            expect(res.text).to.include('citizen-null_1.0.0_linux_amd64.zip');
-            expect(res.text).to.include('citizen-null_1.0.0_windows_amd64.zip');
+            expect(res.text).to.include('terrafrom-provider-null_1.0.0_linux_amd64.zip');
+            expect(res.text).to.include('terrafrom-provider-null_1.0.0_windows_amd64.zip');
           }));
     });
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -90,11 +90,12 @@ module.exports = {
       });
     }
   }),
+
   generateProvider: (prefix, platforms) => new Promise((resolve, reject) => {
-    tmp.dir({ unsafeCleanup: true }, (err, tempDir, cleanupCallback) => {
+    tmp.dir({ unsafeCleanup: !(process.env.CLEANUP) }, (err, tempDir, cleanupCallback) => {
       if (err) { return reject(err); }
 
-      const tfProviderExecutable = `terraform-provider${prefix.substr(prefix.indexOf('-'))}`;
+      const tfProviderExecutable = `terraform-provider-${prefix.substr(prefix.indexOf('-'))}`;
       const content = 'echo provider';
       fs.writeFileSync(tfProviderExecutable, content);
       fs.chmodSync(tfProviderExecutable, 755);
@@ -102,7 +103,7 @@ module.exports = {
       const zip = new AdmZip();
       zip.addFile(tfProviderExecutable, Buffer.alloc(content.length, content));
       platforms.forEach((p) => {
-        zip.writeZip(`${tempDir}/${prefix}_${p}.zip`);
+        zip.writeZip(`${tempDir}/terraform-provider-${prefix}_${p}.zip`);
       });
 
       fs.unlinkSync(tfProviderExecutable);

--- a/test/helper.js
+++ b/test/helper.js
@@ -2,6 +2,7 @@ const nock = require('nock');
 const fs = require('fs');
 const tmp = require('tmp');
 const AdmZip = require('adm-zip');
+const debug = require('debug')('citizen:test:helper:generateProvider');
 
 const { genShaSums, sign } = require('../lib/provider/provider');
 
@@ -92,10 +93,11 @@ module.exports = {
   }),
 
   generateProvider: (prefix, platforms) => new Promise((resolve, reject) => {
-    tmp.dir({ unsafeCleanup: !(process.env.CLEANUP) }, (err, tempDir, cleanupCallback) => {
+    tmp.dir({ unsafeCleanup: true }, (err, tempDir, cleanupCallback) => {
       if (err) { return reject(err); }
 
-      const tfProviderExecutable = `terraform-provider-${prefix.substr(prefix.indexOf('-'))}`;
+      const tfProviderExecutable = `terraform-provider-${prefix}`;
+      debug(`${tfProviderExecutable} in ${tempDir}`);
       const content = 'echo provider';
       fs.writeFileSync(tfProviderExecutable, content);
       fs.chmodSync(tfProviderExecutable, 755);
@@ -103,12 +105,12 @@ module.exports = {
       const zip = new AdmZip();
       zip.addFile(tfProviderExecutable, Buffer.alloc(content.length, content));
       platforms.forEach((p) => {
-        zip.writeZip(`${tempDir}/terraform-provider-${prefix}_${p}.zip`);
+        zip.writeZip(`${tempDir}/${tfProviderExecutable}_${p}.zip`);
       });
 
       fs.unlinkSync(tfProviderExecutable);
 
-      return genShaSums(prefix, tempDir)
+      return genShaSums(`${tfProviderExecutable}`, tempDir)
         .then(async (shaSumsFile) => {
           const sigFile = await sign(shaSumsFile, tempDir);
           return [shaSumsFile, sigFile];

--- a/test/integration/terraform-cli.providers.spec.js
+++ b/test/integration/terraform-cli.providers.spec.js
@@ -59,8 +59,8 @@ TERRAFORM_VERSIONS.forEach((terraform) => {
         terraform {
           required_providers {
             null = {
-              source  = "${url.host}/citizen-test/null"
-              version = "0.1.0"
+              source  = "${url.host}/citizen/null"
+              version = "1.0.0"
             }
           }
         }`;
@@ -105,7 +105,7 @@ TERRAFORM_VERSIONS.forEach((terraform) => {
       before(async () => {
         const client = join(__dirname, '../', '../', 'bin', 'citizen');
 
-        const result = await generateProvider('citizen-null_1.0.0', ['linux_amd64', 'windows_amd64', 'darwin_amd64']);
+        const result = await generateProvider('null_1.0.0', ['linux_amd64', 'windows_amd64', 'darwin_amd64']);
         [tempDir, cleanupProvider] = result;
 
         await new Promise((resolve, reject) => {


### PR DESCRIPTION
This change allows us to use goreleaser to create provider files without changing the generated dist folder files