### PR TITLE
Add signal handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ data/
 test/terraform-binaries/
 test/integration/fixture/.terraform/
 .secrets
+newrelic_agent.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ ENV NODE_ENV=production
 
 EXPOSE 3000
 
-CMD npm start
+CMD ["npm", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ ENV NODE_ENV=production
 
 EXPOSE 3000
 
-CMD npm run start
+CMD npm start

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,7 +1,35 @@
 const http = require('http');
 const debug = require('debug')('citizen:server');
 
+const logger = require('./logger');
 const app = require('../app');
+
+// eslint-disable-next-line no-unused-vars
+const shutdown = (server) => (_reason, _promise) => {
+  logger.info('Received termination signal');
+  logger.info('Shutting down server');
+  // nr.recordCustomEvent('ServerShutdown', { signals });
+
+  server.close(() => {
+    logger.info('TERMINATING THE APPLICATION');
+    process.exit(0);
+  });
+};
+
+process.on('unhandledRejection', (_reason, promise) => {
+  logger.error(
+    { title: 'Unhandled Rejection at:', promise },
+  );
+  // nr.noticeError(reason);
+  // not entirely sure if that's needed or not.
+  // I'm hoping this releases the promise for garbage collection.
+  promise.catch(() => {});
+});
+
+process.on('uncaughtException', (err) => {
+  logger.error('Uncaught Exception', err);
+  // nr.noticeError(err);
+});
 
 const normalizePort = (val) => {
   const port = parseInt(val, 10);
@@ -24,6 +52,8 @@ const run = () => {
   app.set('port', port);
 
   const server = http.createServer(app);
+  process.on('SIGTERM', shutdown(server));
+  process.on('SIGINT', shutdown(server));
   server.listen(port);
   server.on('error', (error) => {
     if (error.syscall !== 'listen') {


### PR DESCRIPTION
We run in a kubernetes environment and we need the docker image to respect SIGTERM.

```shell
docker logs -f nifty_napier

> citizen@0.6.0 start
> node ./bin/citizen server

npm ERR! path /citizen
npm ERR! command failed
npm ERR! signal SIGTERM
npm ERR! command sh -c node ./bin/citizen server

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2021-11-24T18_58_24_674Z-debug.log
```

Note:

Specifying CMD as a string causes the `docker-entrypoint.sh` to run the node application in a shell, which does not propagate the SIGTERM .

```shell
CMD npm run start
```

Changing the CMD to an array runs the ARGS directly as a node process on pid 1 and allows the SIGTERM to be handled by the application.



