### PR TITLE
fix(ci): semantic release should update the package lock version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "citizen",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "citizen",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@aws-sdk/client-s3": "3.42.0",
         "@evops/hcl-terraform-parser": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,8 @@
         {
           "assets": [
             "docs/CHANGELOG.md",
-            "package.json"
+            "package.json",
+            "package-lock.json"
           ],
           "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
         }


### PR DESCRIPTION
The _package-lock.json_ file was synced to the package version when running `npm install` after the version was bumped. 

This should be handled by the semantic-release process.