### PR TITLE
chore(ci): only test node 16

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -17,8 +17,6 @@ jobs:
     strategy:
       matrix:
         node:
-          - 12
-          - 14
           - 16
 
     steps:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -17,8 +17,6 @@ jobs:
     strategy:
       matrix:
         node:
-          - 12
-          - 14
           - 16
     services:
       mongodb:


### PR DESCRIPTION
We only build images and CLI releases with node16, therefore, reduce PR build time and only test with node16.
